### PR TITLE
adjusting to setup community repo by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,22 +5,22 @@
   contributors as indicated by the @author tags. All rights reserved.
   See the copyright.txt in the distribution for a full listing of
   individual contributors.
-  
+
   This is free software; you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License as
   published by the Free Software Foundation; either version 2.1 of
   the License, or (at your option) any later version.
-  
+
   This software is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
   Lesser General Public License for more details.
-  
+
   You should have received a copy of the GNU Lesser General Public
   License along with this software; if not, write to the Free
   Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  
+
   @author <a href="mailto:rtsang@redhat.com">Ray Tsang</a>
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -35,37 +35,36 @@
     <description>A starter Java EE 6 webapp project for use on JBoss AS 7.1 / EAP 6, generated from the jboss-javaee6-webapp archetype</description>
 
     <properties>
-        <!-- Explicitly declaring the source encoding eliminates the following 
+        <!-- Explicitly declaring the source encoding eliminates the following
             message: -->
-        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want 
+        <!-- Define the version of JBoss' Java EE 6 APIs and Tools we want
             to import. -->
         <jboss.bom.version>1.0.0.Final</jboss.bom.version>
-        <!-- Alternatively, comment out the above line, and un-comment the 
-            line below to use version 1.0.0.M12-redhat-1 which is a release certified 
-            to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6 
+        <!-- Alternatively, comment out the above line, and un-comment the
+            line below to use version 1.0.0.M12-redhat-1 which is a release certified
+            to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6
             maven repository. -->
         <!-- <jboss.bom.version>1.0.0.M12-redhat-1</jboss.bom.version>> -->
-        
-        <!-- This is the JDG version, please make sure JDG repository is setup (see README.md) -->
-        <infinispan.version>5.1.5.FINAL-redhat-1</infinispan.version>
-        <!-- For community version, remove -redhat-1
-        	<infinispan.version>5.1.5.FINAL</infinispan.version>
-        -->
+
+        <!-- This is the JDG version, please make sure JDG repository is setup (see README.md)
+        <infinispan.version>5.1.5.FINAL-redhat-1</infinispan.version> -->
+        <!-- For community version, remove -redhat-1 -->
+        <infinispan.version>5.1.5.FINAL</infinispan.version>
     </properties>
 
 
     <dependencyManagement>
         <dependencies>
-            <!-- JBoss distributes a complete set of Java EE 6 APIs including 
-                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or 
-                a collection) of artifacts. We use this here so that we always get the correct 
-                versions of artifacts. Here we use the jboss-javaee-6.0-with-tools stack 
-                (you can read this as the JBoss stack of the Java EE 6 APIs, with some extras 
-                tools for your project, such as Arquillian for testing) and the jboss-javaee-6.0-with-hibernate 
-                stack you can read this as the JBoss stack of the Java EE 6 APIs, with extras 
+            <!-- JBoss distributes a complete set of Java EE 6 APIs including
+                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                a collection) of artifacts. We use this here so that we always get the correct
+                versions of artifacts. Here we use the jboss-javaee-6.0-with-tools stack
+                (you can read this as the JBoss stack of the Java EE 6 APIs, with some extras
+                tools for your project, such as Arquillian for testing) and the jboss-javaee-6.0-with-hibernate
+                stack you can read this as the JBoss stack of the Java EE 6 APIs, with extras
                 from the Hibernate family of projects) -->
             <dependency>
                 <groupId>org.jboss.bom</groupId>
@@ -83,13 +82,13 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <dependencies>
 
-        <!-- First declare the APIs we depend on and need for compilation. 
+        <!-- First declare the APIs we depend on and need for compilation.
             All of them are provided by JBoss AS 7 -->
 
-        <!-- Import the CDI API, we use provided scope as the API is included 
+        <!-- Import the CDI API, we use provided scope as the API is included
             in JBoss AS 7 -->
         <dependency>
             <groupId>javax.enterprise</groupId>
@@ -97,7 +96,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Import the Common Annotations API (JSR-250), we use provided 
+        <!-- Import the Common Annotations API (JSR-250), we use provided
             scope as the API is included in JBoss AS 7 -->
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -105,7 +104,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Import the JAX-RS API, we use provided scope as the API is included 
+        <!-- Import the JAX-RS API, we use provided scope as the API is included
             in JBoss AS 7 -->
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
@@ -119,13 +118,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
         	<groupId>org.infinispan</groupId>
         	<artifactId>infinispan-client-hotrod</artifactId>
         	<version>${infinispan.version}</version>
         </dependency>
-        
+
         <!-- These dependecies are needed to connect to JBoss JMX -->
         <dependency>
         	<groupId>org.jboss.remoting3</groupId>
@@ -145,11 +144,11 @@
     </dependencies>
 
     <build>
-        <!-- Maven will append the version to the finalName (which is the 
+        <!-- Maven will append the version to the finalName (which is the
             name given to the generated war, and hence the context root) -->
         <finalName>${project.artifactId}</finalName>
         <plugins>
-            <!-- Compiler plugin enforces Java 1.6 compatibility and activates 
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates
                 annotation processors -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -163,12 +162,12 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>2.1.1</version>
                 <configuration>
-                    <!-- Java EE 6 doesn't require web.xml, Maven needs to 
+                    <!-- Java EE 6 doesn't require web.xml, Maven needs to
                         catch up! -->
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
-            <!-- The JBoss AS plugin deploys your war to a local JBoss AS 
+            <!-- The JBoss AS plugin deploys your war to a local JBoss AS
                 container -->
             <!-- To use, run: mvn package jboss-as:deploy -->
             <plugin>
@@ -181,9 +180,9 @@
 
     <profiles>
         <profile>
-            <!-- The default profile skips all tests, though you can tune 
+            <!-- The default profile skips all tests, though you can tune
                 it to run just unit tests based on a custom pattern -->
-            <!-- Seperate profiles are provided for running all tests, including 
+            <!-- Seperate profiles are provided for running all tests, including
                 Arquillian tests that execute in the specified container -->
             <id>default</id>
             <activation>


### PR DESCRIPTION
The JDG repo 5.1.0.FINAL-redhat-1 isn't available for download anymore. I think the default option should be community because is witch is available today.
